### PR TITLE
Fix omniauth-oauth2 v1.4 compatibility

### DIFF
--- a/lib/omniauth-beeminder/version.rb
+++ b/lib/omniauth-beeminder/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Beeminder
-    VERSION = "0.1.0"
+    VERSION = "0.1.2"
   end
 end

--- a/lib/omniauth/strategies/beeminder.rb
+++ b/lib/omniauth/strategies/beeminder.rb
@@ -12,8 +12,8 @@ module OmniAuth
         :response_type => 'token'
       }
 
-      uid { 
-        raw_info['username'] 
+      uid {
+        raw_info['username']
       }
 
       info do
@@ -21,6 +21,10 @@ module OmniAuth
           'id' => raw_info['username'],
           'nickname' => raw_info['username'],
         }
+      end
+
+      def callback_url
+        full_host + script_name + callback_path
       end
 
       def raw_info

--- a/omniauth-beeminder.gemspec
+++ b/omniauth-beeminder.gemspec
@@ -8,6 +8,6 @@ Gem::Specification.new do |gem|
   gem.homepage = 'https://github.com/beeminder/omniauth-beeminder'
   gem.require_paths = ['lib']
   gem.summary = %q{Omniauth strategy for Beeminder}
-  gem.add_dependency 'omniauth-oauth2', '>= 1.1.1'
-  gem.version = "0.1.0"
+  gem.add_dependency 'omniauth-oauth2', ['>= 1.1.1','< 1.4.0']
+  gem.version = "0.1.1"
 end

--- a/omniauth-beeminder.gemspec
+++ b/omniauth-beeminder.gemspec
@@ -8,6 +8,6 @@ Gem::Specification.new do |gem|
   gem.homepage = 'https://github.com/beeminder/omniauth-beeminder'
   gem.require_paths = ['lib']
   gem.summary = %q{Omniauth strategy for Beeminder}
-  gem.add_dependency 'omniauth-oauth2', ['>= 1.1.1','< 1.4.0']
-  gem.version = "0.1.1"
+  gem.add_dependency 'omniauth-oauth2', ['>= 1.1.1']
+  gem.version = "0.1.2"
 end


### PR DESCRIPTION
Version 1.4 sends the full url (including query string) when validating tokens. This is incompatible with beeminder.com api.
